### PR TITLE
fixed issue at 320px 

### DIFF
--- a/styles/ln-pp.css
+++ b/styles/ln-pp.css
@@ -623,6 +623,7 @@ h3 {
         justify-content: space-between;
         flex-grow: 0;
         font-size: 16px;
+        gap: 8px;
         padding: 0 8px;
         width: 100%;
         max-width: 400px;


### PR DESCRIPTION
with logged-in versions of legal notice and privacy policy, where the word summary was cut off -> fixed gap from 16px to 8px